### PR TITLE
added support for a readonly configuration property

### DIFF
--- a/src/restapi.plugin.coffee
+++ b/src/restapi.plugin.coffee
@@ -56,6 +56,13 @@ module.exports = (BasePlugin) ->
 					message: err.message+': \n'+err.stack.toString()
 				)
 
+			# Send Unauthorized
+			sendUnauthorized = (res) ->
+				res.status(403).send(
+					success: false
+					message: "Unauthorized"
+				)
+
 			# Prepare file data for sending
 			prepareFile = (file, additionalFields) ->
 				# Prepare
@@ -459,8 +466,12 @@ module.exports = (BasePlugin) ->
 				# Prepare
 				method = req.method.toLowerCase()
 
+				# Check readonly
+				if plugin.config.readonly and method isnt 'get'
+					sendUnauthorized(res)
+
 				# GET / READ
-				if method is 'get'
+				else if method is 'get'
 					# Fetch
 					collectionName = req.params.collectionName
 					relativePath = req.params[0]


### PR DESCRIPTION
I have added a readonly property to the plugin configuration. When this property is true any post, delete or put requests are sent a 403 forbidden response. 
